### PR TITLE
Add Travis configuration for CD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,33 @@
 language: node_js
 node_js:
+  - "10"
   - "8"
 
-services:
-  - docker
+cache:
+  directories:
+    - "node_modules"
 
-install:
-  - npm install
+if: tag IS blank
 
 script:
   - npm run lint
-  - npm run test
+  - npm test
+
+jobs:
+  include:
+    - stage: npm release
+
+      if: branch = master
+
+      script: echo publishing...
+
+      before_deploy:
+        - export VERSION_TAG=$(git ls-remote origin | grep "$TRAVIS_COMMIT\s\+refs/tags/v[0-9]\+\.[0-9]\+\.[0-9]\+\^{}$")
+        - echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+        - npm i --global otp-cli
+        - export NPM_OTP=$(otp-cli totp generate -k "$NPM_OTP_SECRET")
+      deploy:
+        provider: script
+        script: if [ -n "$VERSION_TAG" ]; then npm publish --access public --otp "$NPM_OTP"; else echo commit not tagged; fi
+        skip_cleanup: true
+      after_deploy: rm ~/.npmrc


### PR DESCRIPTION
This will enable Travis to publish to `npm` once a commit is tagged with `npm version` and merged into `master`.

Travis configuration for for this repo is already configured with the proper secrets.

Resolves #5 